### PR TITLE
feat: aggregate golden sweep tracking

### DIFF
--- a/.github/workflows/sweeps.yml
+++ b/.github/workflows/sweeps.yml
@@ -49,6 +49,7 @@ jobs:
           MAX_DTE_GOLDEN:     ${{ vars.MAX_DTE_GOLDEN }}
           MIN_VOL_OI:     ${{ vars.MIN_VOL_OI }}
           AGGRESSIVE_LAST_TO_ASK:     ${{ vars.AGGRESSIVE_LAST_TO_ASK }}
+          HISTORY_MINUTES:     ${{ vars.HISTORY_MINUTES }}
         run: node index.mjs
 
       # 3) Commit & push only if there are changes


### PR DESCRIPTION
## Summary
- persist `recent` history alongside `posted` markers and trim it by a configurable window
- aggregate recent contracts to detect and post "golden" sweeps only once per contract
- expose `HISTORY_MINUTES` workflow variable so the history window can be tuned
- keep existing per-row large sweep logic and mark posted contracts & rows

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb6020f0ec832986ee902aa09e4fe9